### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -3,7 +3,7 @@ Docklr
 .. image:: https://travis-ci.org/drichner/docklr.svg?branch=master
     :target: https://travis-ci.org/drichner/docklr
 
-.. image:: https://pypip.in/license/Docklr/badge.png
+.. image:: https://img.shields.io/pypi/l/Docklr.svg
     :target: https://pypi.python.org/pypi/Docklr/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20docklr))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `docklr`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.